### PR TITLE
Use DOMPurify for HTML injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,8 @@
         "vaul": "^0.9.3",
         "vitest": "^3.2.4",
         "zod": "^3.23.8",
-        "zustand": "^5.0.6"
+        "zustand": "^5.0.6",
+        "dompurify": "^3.2.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -90,6 +91,7 @@
         "@types/node": "^22.5.5",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@types/dompurify": "^3.0.2",
         "@vitejs/plugin-react-swc": "^3.5.0",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.9.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "vaul": "^0.9.3",
     "vitest": "^3.2.4",
     "zod": "^3.23.8",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "dompurify": "^3.2.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
@@ -93,6 +94,7 @@
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/dompurify": "^3.0.2",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.9.0",

--- a/src/components/collaborators/AgreementViewDialog.tsx
+++ b/src/components/collaborators/AgreementViewDialog.tsx
@@ -6,6 +6,7 @@ import { Collaborator } from '@/types/Collaborator';
 import { useDocuments } from '@/hooks/useDocuments';
 import { Download, Send, FileText } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import DOMPurify from 'dompurify';
 
 interface AgreementViewDialogProps {
   collaborator: Collaborator | null;
@@ -147,10 +148,10 @@ export const AgreementViewDialog: React.FC<AgreementViewDialogProps> = ({
 
         {agreement && (
           <div className="mt-6">
-            <div 
+            <div
               className="prose max-w-none border rounded-lg p-6 bg-white min-h-[400px] text-sm"
-              dangerouslySetInnerHTML={{ 
-                __html: processContent(agreement.content?.content || '') 
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(processContent(agreement.content?.content || ''))
               }}
             />
           </div>
@@ -167,5 +168,4 @@ export const AgreementViewDialog: React.FC<AgreementViewDialogProps> = ({
         )}
       </DialogContent>
     </Dialog>
-  );
-};
+  );};

--- a/src/components/documents/DocumentEditor.tsx
+++ b/src/components/documents/DocumentEditor.tsx
@@ -14,6 +14,7 @@ import { Document, DocumentTemplate } from '@/types/Document';
 import { useToast } from '@/hooks/use-toast';
 import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';
+import DOMPurify from 'dompurify';
 
 interface DocumentEditorProps {
   document?: Document;
@@ -98,7 +99,7 @@ export const DocumentEditor: React.FC<DocumentEditorProps> = ({ document, templa
     try {
       // Create a temporary div with the processed content
       const tempDiv = window.document.createElement('div');
-      tempDiv.innerHTML = processContent(content);
+      tempDiv.innerHTML = DOMPurify.sanitize(processContent(content));
       tempDiv.style.position = 'absolute';
       tempDiv.style.left = '-9999px';
       tempDiv.style.width = '800px';
@@ -273,9 +274,9 @@ export const DocumentEditor: React.FC<DocumentEditorProps> = ({ document, templa
               <CardTitle>Vista Previa</CardTitle>
             </CardHeader>
             <CardContent>
-              <div 
+              <div
                 className="prose max-w-none border rounded-lg p-4 bg-white min-h-[200px]"
-                dangerouslySetInnerHTML={{ __html: processContent(content) }}
+                dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(processContent(content)) }}
               />
             </CardContent>
           </Card>

--- a/src/components/email/EmailViewer.tsx
+++ b/src/components/email/EmailViewer.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import './email-styles.css';
+import DOMPurify from 'dompurify';
 
 interface EmailViewerProps {
   email: TrackedEmail | null;
@@ -79,9 +80,9 @@ export const EmailViewer: React.FC<EmailViewerProps> = ({
     // Si es HTML, renderizar como HTML
     if (email.content.includes('<')) {
       return (
-        <div 
+        <div
           className="email-content prose prose-sm max-w-none"
-          dangerouslySetInnerHTML={{ __html: email.content }}
+          dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(email.content) }}
         />
       );
     }

--- a/src/pages/MinimalEmail.tsx
+++ b/src/pages/MinimalEmail.tsx
@@ -5,6 +5,7 @@ import { useEmailTracking } from '@/hooks/useEmailTracking';
 import { Mail } from 'lucide-react';
 import { TrackedEmail } from '@/types/EmailTracking';
 import { EmailComposer } from '@/components/email/EmailComposer';
+import DOMPurify from 'dompurify';
 
 export default function MinimalEmail() {
   const [selectedEmail, setSelectedEmail] = useState<TrackedEmail | null>(null);
@@ -198,10 +199,10 @@ export default function MinimalEmail() {
               </div>
               
               <div className="prose prose-sm max-w-none">
-                <div 
+                <div
                   className="text-gray-800 leading-relaxed"
-                  dangerouslySetInnerHTML={{ 
-                    __html: selectedEmail.content || 'Sin contenido' 
+                  dangerouslySetInnerHTML={{
+                    __html: DOMPurify.sanitize(selectedEmail.content || 'Sin contenido')
                   }}
                 />
               </div>


### PR DESCRIPTION
## Summary
- add DOMPurify dependency
- sanitize HTML in document editor preview and PDF generation
- sanitize HTML rendering in email viewer and collaborator agreement dialog
- sanitize HTML in minimal email page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d62851e98832898b76558366a919e